### PR TITLE
Improvements with parameters encoding

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
     - RxSwift (~> 5)
   - RxRelay (5.0.0):
     - RxSwift (~> 5)
-  - RxRestClient (1.2.1):
+  - RxRestClient (1.3.0):
     - Alamofire (~> 4)
     - RxAlamofire (~> 5)
     - RxCocoa (~> 5)
@@ -65,7 +65,7 @@ SPEC CHECKSUMS:
   RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
   RxOptional: 9904e2219d59260c3c171273d475b2126de187e8
   RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
-  RxRestClient: 4bf25b1d2355c6f6815d0d71f2f6e32e3d34f0d9
+  RxRestClient: 63e5a2cf7ceeeed169eb40925fb9a6c31a806fe0
   RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
   SDWebImage: 3f3f0c02f09798048c47a5ed0a13f17b063572d8
 

--- a/RxRestClient.podspec
+++ b/RxRestClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RxRestClient'
-  s.version          = '1.2.1'
+  s.version          = '1.3.0'
   s.summary          = 'Simple REST Client based on RxSwift and Alamofire.'
   s.swift_version = '5.0'
 

--- a/RxRestClient/Classes/RxRestClient.swift
+++ b/RxRestClient/Classes/RxRestClient.swift
@@ -20,8 +20,8 @@ public struct RxRestClientOptions {
     public var headers = ["Content-Type": "application/json"]
     public var maxConcurrentOperationCount = 2
     public var logger: RxRestClientLogger?
-    public var urlEncoding: ParameterEncoding = URLEncoding.default
-    public var jsonEncoding: ParameterEncoding = JSONEncoding.default
+    public var queryEncoding: ParameterEncoding = URLEncoding.default
+    public var bodyEncoding: ParameterEncoding = JSONEncoding.default
     public var jsonDecoder: JSONDecoder = JSONDecoder()
     public var jsonEncoder: JSONEncoder = JSONEncoder()
     public var sessionManager: SessionManager?
@@ -99,7 +99,7 @@ open class RxRestClient {
     ///   - object: dictinary representing body of request
     /// - Returns: An observable of a the response state
     public func post<T: ResponseState>(url: URL, object: [String: Any]) -> Observable<T> {
-        return run(request(.post, url, object: object))
+        return run(request(.post, url, object: object, encoding: options.bodyEncoding))
     }
 
     /// Do POST Request
@@ -159,7 +159,7 @@ open class RxRestClient {
     ///   - object: dictinary representing body of request
     /// - Returns: An observable of a the response state
     public func put<T: ResponseState>(url: URL, object: [String: Any]) -> Observable<T> {
-        return run(request(.put, url, object: object))
+        return run(request(.put, url, object: object, encoding: options.bodyEncoding))
     }
     
     /// Do PUT Request
@@ -219,7 +219,7 @@ open class RxRestClient {
     ///   - object: dictinary representing body of request
     /// - Returns: An observable of a the response state
     public func patch<T: ResponseState>(url: URL, object: [String: Any]) -> Observable<T> {
-        return run(request(.patch, url, object: object))
+        return run(request(.patch, url, object: object, encoding: options.bodyEncoding))
     }
 
     /// Do PATCH Request
@@ -256,30 +256,7 @@ open class RxRestClient {
     ///   - object: dictinary representing body of request, default value is empty
     /// - Returns: An observable of a the response state
     public func delete<T: ResponseState>(url: URL, object: [String: Any] = [:]) -> Observable<T> {
-        return run(request(.delete, url, object: object))
-    }
-
-    /// Do DELETE Request
-    ///
-    /// - Parameters:
-    ///   - endpoint: Relative path of endpoint which will be appended to baseUrl
-    ///   - array: array representing body of request, default value is empty
-    /// - Returns: An observable of a the response state
-    public func delete<T: ResponseState>(_ endpoint: String, array: [Any]) -> Observable<T> {
-        guard let url = buildURL(endpoint) else {
-            return Observable.error(RxRestClientError.urlBuildFailed)
-        }
-        return delete(url: url, array: array)
-    }
-
-    /// Do DELETE Request
-    ///
-    /// - Parameters:
-    ///   - url: absalute url
-    ///   - array: array representing body of request, default value is empty
-    /// - Returns: An observable of a the response state
-    public func delete<T: ResponseState>(url: URL, array: [Any]) -> Observable<T> {
-        return run(request(.delete, url, array: array))
+        return run(request(.delete, url, object: object, encoding: options.queryEncoding))
     }
 
     /// Do DELETE Request
@@ -316,7 +293,7 @@ open class RxRestClient {
     ///   - query: dictinary representing query of request, default value is empty
     /// - Returns: An observable of a the response state
     public func get<T: ResponseState>(url: URL, query: [String: Any] = [:]) -> Observable<T> {
-        return run(request(.get, url, object: query, encoding: options.urlEncoding))
+        return run(request(.get, url, object: query, encoding: options.queryEncoding))
     }
 
     /// Do GET Request
@@ -432,12 +409,12 @@ open class RxRestClient {
     ///   - object: A dictionary containing all necessary options
     ///   - encoding: The kind of encoding used to process parameters
     /// - Returns: An observable of a the created DataRequest
-    public func request(_ method: HTTPMethod, _ url: URLConvertible, object: [String: Any], encoding: ParameterEncoding? = nil) -> Observable<DataRequest> {
+    public func request(_ method: HTTPMethod, _ url: URLConvertible, object: [String: Any], encoding: ParameterEncoding) -> Observable<DataRequest> {
         return getSessionManager().rx.request(
             method,
             url,
             parameters: object,
-            encoding: encoding ?? options.jsonEncoding,
+            encoding: encoding,
             headers: options.headers
         )
     }


### PR DESCRIPTION
Renaming jsonEncoding option to bodyEncoding
Renaming urlEncoding option to queryEncoding
Removing delete request via array
Using bodyEncoding from options for `post`, `put`, `patch` requests
Using queryEncoding from options for `get`, `delete` requests
Bumped version number to 1.3.0